### PR TITLE
Add delete original option

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -336,12 +336,18 @@
                                 </StackPanel>
                             </Grid>
 
-                            <Button 
+                            <Button
                                 Content="📁 Seleccionar Archivo para Encriptar"
                                 Style="{StaticResource AccentButton}"
                                 Click="EncryptFile_Click"
                                 HorizontalAlignment="Center"
                                 Margin="0,16,0,0"/>
+
+                            <CheckBox
+                                x:Name="DeleteOriginalCheckBox"
+                                Content="Eliminar archivo original después de encriptar"
+                                Style="{StaticResource ModernCheckBox}"
+                                Margin="0,8,0,0"/>
                         </StackPanel>
                     </Border>
                 </StackPanel>


### PR DESCRIPTION
## Summary
- add a checkbox to optionally remove the original file after encryption
- delete the source file when encryption succeeds if the option is checked

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688ca89a8b288320a1e4c9d0365a9638