### PR TITLE
Add compression before encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Una aplicación moderna y segura para encriptar archivos con AES-256, desarrolla
 - **Preservación de Nombres**: Mantiene metadatos del archivo original
 - **Múltiples Métodos**: Encripta con contraseña o desencripta con frase de recuperación
 - **Operaciones Asíncronas**: Procesamiento no bloqueante con progreso visual
+- **Compresión Integrada**: Archivos comprimidos automáticamente antes de ser encriptados
 
 ## 🚀 Instalación
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Una aplicación moderna y segura para encriptar archivos con AES-256, desarrolla
 - **Preservación de Nombres**: Mantiene metadatos del archivo original
 - **Múltiples Métodos**: Encripta con contraseña o desencripta con frase de recuperación
 - **Operaciones Asíncronas**: Procesamiento no bloqueante con progreso visual
-- **Compresión Integrada**: Archivos comprimidos automáticamente antes de ser encriptados
+- **Compresión Integrada**: Archivos comprimidos con Brotli en modo rápido para acelerar la encriptación
 
 ## 🚀 Instalación
 

--- a/Services/EncryptionService.cs
+++ b/Services/EncryptionService.cs
@@ -71,7 +71,8 @@ namespace FileEncrypter.Services
             long totalBytes = new FileInfo(inputPath).Length;
             writer.Write(totalBytes);
 
-            using var compressor = new BrotliStream(crypto, CompressionLevel.SmallestSize, leaveOpen: true);
+            // Use fastest compression level to speed up encryption
+            using var compressor = new BrotliStream(crypto, CompressionLevel.Fastest, leaveOpen: true);
 
             byte[] buffer = new byte[BufferSize];
             long readSoFar = 0;


### PR DESCRIPTION
## Summary
- compress file data with Brotli before encrypting
- decompress after decryption
- document new compression feature

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688d04c6e7a48320bfb3d12711f12564